### PR TITLE
Add post json decode hook

### DIFF
--- a/src/Structr/Tree/Base/PrototypeNode.php
+++ b/src/Structr/Tree/Base/PrototypeNode.php
@@ -31,7 +31,7 @@ abstract class PrototypeNode extends Node
     /**
      * @var \Structr\Tree\Base\Node Child node declaring type
      */
-    private $_prototype = null;
+    protected $_prototype = null;
 
     /**
      * Get the Prototype of this Node, i.e., the concrete

--- a/src/Structr/Tree/Composite/ChoiceNode.php
+++ b/src/Structr/Tree/Composite/ChoiceNode.php
@@ -12,6 +12,7 @@ use Structr\Tree\Base\Node;
 
 use Structr\Tree\Composite\ChoicePrototypeNode;
 use Structr\Exception;
+use Structr\Tree\Scalar\NullNode;
 
 class ChoiceNode extends Node
 {
@@ -29,6 +30,19 @@ class ChoiceNode extends Node
     public function addAlternative($alternative)
     {
         $this->_alternatives[] = $alternative;
+    }
+
+    public function canHaveNullValue()
+    {
+        foreach($this->_alternatives as $alternative)
+        {
+            if(NullNode::canHaveNullValue($alternative))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Structr/Tree/Composite/JsonListNode.php
+++ b/src/Structr/Tree/Composite/JsonListNode.php
@@ -13,11 +13,54 @@ use Structr\Structr;
 class JsonListNode extends ListNode
 {
     /**
+     * @var array functions to apply to the value of this node
+     *      after decoding, but before checking the value of this node
+     */
+    private $_post_decode = array();
+
+    /**
+     * Add a post-decode-processing callable to this node.
+     * Post-decode-processing callables are applied to the value of this node just
+     * after the decoding the value, but just before the value is checked.
+     * The callables are applied in the order in which they are added.
+     *
+     * @param mixed $callable A valid PHP callable
+     * @throws \Structr\Exception
+     * @return \Structr\Tree\Base\Node This node
+     */
+    public function post_decode($callable)
+    {
+        if (is_callable($callable, false)) {
+            $this->_post_decode[] = $callable;
+        } else {
+            throw new Exception('Invalid callable supplied to JsonListNode::post_decode()');
+        }
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function _walk_value($value = null)
     {
         $value = Structr::json_decode($value);
+        $value = $this->_walk_post_decode($value);
         return parent::_walk_value($value);
+    }
+
+    /**
+     * Apply all post-processing callables to a value
+     *
+     * @param mixed $value The value to process
+     * @return mixed Result of all pre-processing callables
+     */
+    protected function _walk_post_decode($value)
+    {
+        foreach ($this->_post_decode as $callable) {
+            $value = call_user_func($callable, $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Structr/Tree/Composite/JsonMapNode.php
+++ b/src/Structr/Tree/Composite/JsonMapNode.php
@@ -13,11 +13,54 @@ use Structr\Structr;
 class JsonMapNode extends MapNode
 {
     /**
+     * @var array functions to apply to the value of this node
+     *      after decoding, but before checking the value of this node
+     */
+    private $_post_decode = array();
+
+    /**
+     * Add a post-decode-processing callable to this node.
+     * Post-decode-processing callables are applied to the value of this node just
+     * after the decoding the value, but just before the value is checked.
+     * The callables are applied in the order in which they are added.
+     *
+     * @param mixed $callable A valid PHP callable
+     * @throws \Structr\Exception
+     * @return \Structr\Tree\Base\Node This node
+     */
+    public function post_decode($callable)
+    {
+        if (is_callable($callable, false)) {
+            $this->_post_decode[] = $callable;
+        } else {
+            throw new Exception('Invalid callable supplied to JsonMapNode::post_decode()');
+        }
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function _walk_value($value = null)
     {
         $value = Structr::json_decode($value);
+        $value = $this->_walk_post_decode($value);
         return parent::_walk_value($value);
+    }
+
+    /**
+     * Apply all post-processing callables to a value
+     *
+     * @param mixed $value The value to process
+     * @return mixed Result of all pre-processing callables
+     */
+    protected function _walk_post_decode($value)
+    {
+        foreach ($this->_post_decode as $callable) {
+            $value = call_user_func($callable, $value);
+        }
+
+        return $value;
     }
 }

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -62,7 +62,7 @@ class MapKeyNode extends PrototypeNode
      */
     public function description($description)
     {
-        $this->_prototype->setDescription($description);
+        $this->setDescription($description);
         return $this;
     }
 
@@ -73,7 +73,11 @@ class MapKeyNode extends PrototypeNode
      */
     public function getDescription()
     {
-        return $this->_prototype->getDescription();
+        $description = $this->getDescription();
+        if(empty($description) && isset($this->_prototype)) {
+            $description = $this->_prototype->getDescription();
+        }
+        return empty($description) ? "" : $description;
     }
 
     /**
@@ -83,7 +87,7 @@ class MapKeyNode extends PrototypeNode
      */
     public function setDescription($description)
     {
-        $this->_prototype->setDescription($description);
+        $this->setDescription($description);
     }
 
     /**

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -73,7 +73,7 @@ class MapKeyNode extends PrototypeNode
      */
     public function getDescription()
     {
-        $description = $this->getDescription();
+        $description = $this->description;
         if(empty($description) && isset($this->_prototype)) {
             $description = $this->_prototype->getDescription();
         }

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -87,7 +87,7 @@ class MapKeyNode extends PrototypeNode
      */
     public function setDescription($description)
     {
-        $this->setDescription($description);
+        $this->description = $description;
     }
 
     /**

--- a/src/Structr/Tree/Composite/MapKeyNode.php
+++ b/src/Structr/Tree/Composite/MapKeyNode.php
@@ -74,7 +74,7 @@ class MapKeyNode extends PrototypeNode
     public function getDescription()
     {
         $description = $this->description;
-        if(empty($description) && isset($this->_prototype)) {
+        if (empty($description) && isset($this->_prototype)) {
             $description = $this->_prototype->getDescription();
         }
         return empty($description) ? "" : $description;

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -11,6 +11,7 @@ namespace Structr\Tree\Composite;
 use Structr\Tree\Base\Node;
 
 use Structr\Exception;
+use Structr\Tree\Scalar\NullNode;
 
 class MapNode extends Node
 {
@@ -145,6 +146,12 @@ class MapNode extends Node
             if (isset($value[$key])) {
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
+                if(array_key_exists($key, $value)) {
+                    if(NullNode::canHaveNullValue($value)) {
+                        $return[$key] = null;
+                    }
+                    unset($value[$key]);
+                }
                 continue;
             } else {
                 $return[$key] = $val->_walk_post($val->_walk_value_unset());

--- a/src/Structr/Tree/Scalar/NullNode.php
+++ b/src/Structr/Tree/Scalar/NullNode.php
@@ -8,7 +8,9 @@
 
 namespace Structr\Tree\Scalar;
 
+use Structr\Tree\Base\Node;
 use Structr\Tree\Base\ScalarNode;
+use Structr\Tree\Composite\ChoiceNode;
 
 class NullNode extends ScalarNode
 {
@@ -18,5 +20,21 @@ class NullNode extends ScalarNode
     public function getScalarType()
     {
         return 'NULL';
+    }
+
+    /**
+     * @param Node $node
+     */
+    public static function canHaveNullValue($node)
+    {
+        if($node instanceof NullNode) {
+            return true;
+        }
+
+        if($node instanceof ChoiceNode) {
+            return $node->canHaveNullValue();
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR adds a new point at which we can intercept the Structr validation process to manipulate the value of the object being validated.

This hook is the "post_decode" hook. The purpose of this hook is to perform some modification on the value after it has been decoded from json, but before it is validated.

This is required because the "pre" hook applies the changes before the object is decoded from json, and we need to snake_case the incoming values after they have been decoded from json, but before they are validated.

Please be aware that this PR contains the changes from: https://github.com/Yellitech/Structr/pull/4