### PR TITLE
Fix: Null values being stripped out by structr

### DIFF
--- a/src/Structr/Tree/Composite/ChoiceNode.php
+++ b/src/Structr/Tree/Composite/ChoiceNode.php
@@ -9,8 +9,6 @@
 namespace Structr\Tree\Composite;
 
 use Structr\Tree\Base\Node;
-
-use Structr\Tree\Composite\ChoicePrototypeNode;
 use Structr\Exception;
 
 class ChoiceNode extends Node

--- a/src/Structr/Tree/Composite/JsonMapNode.php
+++ b/src/Structr/Tree/Composite/JsonMapNode.php
@@ -9,9 +9,37 @@
 namespace Structr\Tree\Composite;
 
 use Structr\Structr;
+use Exception;
 
 class JsonMapNode extends MapNode
 {
+    /**
+     * @var array functions to apply to the value of this node
+     *      after decoding, but before checking the value of this node
+     */
+    private $_post_decode = array();
+
+    /**
+     * Add a post-decode-processing callable to this node.
+     * Post-decode-processing callables are applied to the value of this node just
+     * after the decoding the value, but just before the value is checked.
+     * The callables are applied in the order in which they are added.
+     *
+     * @param mixed $callable A valid PHP callable
+     * @throws \Structr\Exception
+     * @return MapNode This node
+     */
+    public function post_decode($callable)
+    {
+        if (is_callable($callable, false)) {
+            $this->_post_decode[] = $callable;
+        } else {
+            throw new Exception('Invalid callable supplied to JsonMapNode::post_decode()');
+        }
+
+        return $this;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -19,17 +19,17 @@ class MapNode extends Node
      * @var array Keys currently registered for this map
      */
     private $_keys = array();
-    
+
     /**
      * @var string A regular expression to match certain keys
      */
     private $_regexp_keys = array();
-    
+
     /**
      * @var array A callable to filter keys
      */
     private $_callable_keys = array();
-    
+
     /**
      * @var boolean Whether this map should be strict. A strict map throws an
      *      exception when there are keys it didn't expect.
@@ -38,7 +38,7 @@ class MapNode extends Node
 
     /**
      * Add a key to this map
-     * 
+     *
      * @param string $keyname Name of the key
      * @return \Structr\Tree\Composite\MapKeyNode
      */
@@ -53,7 +53,7 @@ class MapNode extends Node
     /**
      * Add a key-matcher to this map. Either via a callable or a
      * regular expression
-     * 
+     *
      * @param string|mixed $matcher The filter
      * @param string $name Name for the key
      * @return \Structr\Tree\Composite\MapKeyNode
@@ -85,7 +85,7 @@ class MapNode extends Node
 
     /**
      * Remove a key from this map
-     * 
+     *
      * @param string $keyName The name of the key to remove
      * @return \Structr\Tree\Composite\MapNode This node
      */
@@ -100,7 +100,7 @@ class MapNode extends Node
 
     /**
      * Reset this map. Forgetting the current state completely.
-     * 
+     *
      * @return \Structr\Tree\Composite\MapNode This node
      */
     public function clear()
@@ -116,13 +116,13 @@ class MapNode extends Node
     /**
      * Call when this map must be strict, i.e., throw an exception when there
      * are keys in the input that are not described by this map
-     * 
+     *
      * @return \Structr\Tree\Composite\MapNode This node
      */
     public function strict()
     {
         $this->_strict = true;
-        
+
         return $this;
     }
 
@@ -146,7 +146,7 @@ class MapNode extends Node
             if (isset($value[$key])) {
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
-                if(array_key_exists($key, $value)) {
+                if (array_key_exists($key, $value)) {
                     $return[$key] = null;
                     unset($value[$key]);
                 }
@@ -181,7 +181,7 @@ class MapNode extends Node
                 implode(', ', array_keys($value))
             ));
         }
-        
+
         return $return;
     }
 }

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -145,6 +145,9 @@ class MapNode extends Node
             if (isset($value[$key])) {
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
+                if(array_key_exists($key, $value)) {
+                    $return[$key] = $val->_walk($value[$key]);
+                }
                 continue;
             } else {
                 $return[$key] = $val->_walk_post($val->_walk_value_unset());

--- a/src/Structr/Tree/Composite/MapNode.php
+++ b/src/Structr/Tree/Composite/MapNode.php
@@ -147,7 +147,8 @@ class MapNode extends Node
                 $return[$key] = $val->_walk($value[$key]);
             } elseif ($val->isOptional()) {
                 if(array_key_exists($key, $value)) {
-                    $return[$key] = $val->_walk($value[$key]);
+                    $return[$key] = null;
+                    unset($value[$key]);
                 }
                 continue;
             } else {


### PR DESCRIPTION
Issue:
=====
When Structr was processing a map definition, it would strip out keys that had been given null values. It is important that this doesn't happen, because sometimes we want to know that a key was sent with a null value, so that we know we want to save an edit to a property by setting it to null.

For example, this input would be processed and turned into the following input:
```
{
     "propertyOne": "Hi!",
     "propertyTwo":
}
```

```
{
    "propertyOne": "Hi!"
}
```

Solution
======
Check if a key has been provided with a null value, and check if the key is optional. If it is optional, allow the value to pass through as null. If it is not optional, throw an error.

Under no circumstances, remove an expected key that was sent in the payload.

This PR is related to the yellitech/api pr: https://github.com/Yellitech/api/pull/279